### PR TITLE
chore: Add Svelte 5 peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
 		"!dist/images"
 	],
 	"peerDependencies": {
-		"svelte": "^4.0.0"
+		"svelte": "^4.0.0 || ^5.0.0"
 	},
 	"devDependencies": {
 		"@fontsource/fira-mono": "^4.5.10",


### PR DESCRIPTION
Add Svelte 5 as a peer dependency to suppress warnings from package managers.

I don't think there is any reason that this would have issues with Svelte 5. I am using it and I didn't have any issues (outside of the install warning)