### PR TITLE
feat: Added umami sessions (umami.identify)

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Functions:
 
 - trackPageView: Manual page view tracking
 - trackEvent: Event tracking
+- trackSession: Session identification with unique ID and/or session data
 - handleEvent: Svelte event handler for event tracking
 
 Stores:
@@ -150,6 +151,48 @@ You can disable this behavior by adding 'data-auto-track': false to the configur
 />
 
 <button on:click={(e) => trackEvent('button pressed', { key: 'value' })}> Track Event </button>
+```
+
+### Track Sessions (Identify)
+
+https://umami.is/docs/tracker-functions
+
+Use `trackSession` to identify the current session by attaching a unique ID and/or custom session data. This calls the Umami `identify` function under the hood.
+
+#### Identify with a unique ID
+
+```svelte
+<script lang="ts">
+	import { trackSession } from '@lukulent/svelte-umami';
+	import { onMount } from 'svelte';
+	onMount(() => {
+		trackSession('user-123');
+	});
+</script>
+```
+
+#### Identify with a unique ID and session data
+
+```svelte
+<script lang="ts">
+	import { trackSession } from '@lukulent/svelte-umami';
+	import { onMount } from 'svelte';
+	onMount(() => {
+		trackSession('user-123', { email: 'bob@aol.com', name: 'Bob' });
+	});
+</script>
+```
+
+#### Identify with session data only
+
+```svelte
+<script lang="ts">
+	import { trackSession } from '@lukulent/svelte-umami';
+	import { onMount } from 'svelte';
+	onMount(() => {
+		trackSession({ email: 'bob@aol.com', name: 'Bob' });
+	});
+</script>
 ```
 
 ### Helpers

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
 		"build": "vite build && npm run package",
 		"preview": "vite preview",
 		"package": "svelte-kit sync && svelte-package && publint",
+		"prepare": "svelte-kit sync && svelte-package",
 		"prepublishOnly": "npm run package",
 		"test": "npm run test:integration && npm run test:unit",
 		"check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1,5 +1,5 @@
 export { default as UmamiAnalytics } from '$lib/components/UmamiAnalytics.svelte';
 export { default as UmamiAnalyticsEnv } from '$lib/components/UmamiAnalyticsEnv.svelte';
 export { default as UmamiTrackClicks } from '$lib/components/UmamiTrackClicks.svelte';
-export { trackPageView, trackEvent, trackEventWithProperties, handleEvent } from '$lib/tracker';
+export { trackPageView, trackEvent, trackEventWithProperties, handleEvent, trackSession } from '$lib/tracker';
 export { isEnabled, status } from '$lib/stores/umami';

--- a/src/lib/tracker.ts
+++ b/src/lib/tracker.ts
@@ -1,6 +1,7 @@
 import type {
 	EventData,
 	OptionalTrackedProperties,
+	SessionData,
 	TrackedProperties,
 	UmamiTracker,
 	WindowWithUmami
@@ -40,7 +41,10 @@ async function waitForUmami(): Promise<UmamiTracker> {
 	let count = 50; // try max 5 seconds
 	while (!window.umami) {
 		if ([undefined, 'error', 'removed'].includes(get(status)) || count > 0) {
-			return { track: () => Promise.resolve('Umami not found.') };
+			return {
+				track: () => Promise.resolve('Umami not found.'),
+				identify: () => Promise.resolve('Umami not found.')
+			};
 		}
 		await new Promise((resolve) => setTimeout(resolve, 100));
 		count--;
@@ -110,6 +114,33 @@ export function trackEventWithProperties(
 				...properties,
 				name: eventName
 			}));
+		}
+	});
+}
+
+
+/**
+ * Identify the current session with a unique ID and/or session data.
+ * @param uniqueIdOrSessionData A unique identifier string, or a SessionData object to attach to the session.
+ * @param sessionData Optional session data when the first argument is a unique ID string.
+ * @returns
+ */
+export function trackSession(
+	uniqueIdOrSessionData: string | SessionData,
+	sessionData?: SessionData
+): Promise<string> {
+	if (!browser) return Promise.resolve('');
+	if ([undefined, 'error', 'removed'].includes(get(status)))
+		return Promise.resolve('Umami not found.');
+	return waitForUmami().then((umami) => {
+		if (typeof uniqueIdOrSessionData === 'string') {
+			if (sessionData) {
+				return umami.identify(uniqueIdOrSessionData, sessionData);
+			} else {
+				return umami.identify(uniqueIdOrSessionData);
+			}
+		} else {
+			return umami.identify(uniqueIdOrSessionData);
 		}
 	});
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -102,6 +102,13 @@ export type CustomEventFunction = (
 	props: PageViewProperties
 ) => EventProperties | PageViewProperties;
 
+/**
+ *
+ * Session Data can work with any JSON data.
+ */
+type SessionJSON = string | number | boolean | null | SessionJSON[] | { [key: string]: SessionJSON };
+export type SessionData = { [key: string]: SessionJSON };
+
 export type UmamiTracker = {
 	track: {
 		/**
@@ -166,6 +173,35 @@ export type UmamiTracker = {
 		 * ```
 		 */
 		(eventFunction: CustomEventFunction): Promise<string>;
+	};
+
+	identify: {
+		/**
+		 * Assign a unique ID to the current session
+		 *
+		 * @example ```
+		 * umami.identify('user-123');
+		 * ```
+		 */
+		(uniqueId: string): Promise<string>;
+
+		/**
+		 * Assign a unique ID and session data to the current session
+		 *
+		 * @example ```
+		 * umami.identify('user-123', { email: 'bob@aol.com', name: 'Bob' });
+		 * ```
+		 */
+		(uniqueId: string, sessionData: SessionData): Promise<string>;
+
+		/**
+		 * Attach session data to the current session without a unique ID
+		 *
+		 * @example ```
+		 * umami.identify({ email: 'bob@aol.com', name: 'Bob' });
+		 * ```
+		 */
+		(sessionData: SessionData): Promise<string>;
 	};
 };
 

--- a/src/routes/Counter.svelte
+++ b/src/routes/Counter.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-	import { trackEvent, trackPageView } from '$lib';
+	import { trackEvent, trackPageView, trackSession } from '$lib';
+	import { onMount } from 'svelte';
 	import { spring } from 'svelte/motion';
 
 	let count = 0;
@@ -19,7 +20,13 @@
 		// handle negative numbers
 		return ((n % m) + m) % m;
 	}
+
+	onMount(async () => {
+		await trackSession("123456", { email: 'test@test.com', name: 'Test User' });
+	});
 </script>
+
+
 
 <div class="counter">
 	<button


### PR DESCRIPTION
The umami.identify functionality is supported. The documentation, an example in Counter.svelte and the prepare script have been adapted and created.